### PR TITLE
Fixed set_multiple_pixels

### DIFF
--- a/library/rgbmatrix5x5/is31fl3731.py
+++ b/library/rgbmatrix5x5/is31fl3731.py
@@ -266,7 +266,7 @@ class Matrix:
                 x = index % 5
             else:
                 x, y = index
-            display.set_pixel(x, y, from_r + (step_r * step), from_g + (step_g * step), from_b + (step_b * step))
+            self.set_pixel(x, y, from_r + (step_r * step), from_g + (step_g * step), from_b + (step_b * step))
             step += 1
 
     def get_shape(self):


### PR DESCRIPTION
Changed "display.set_pixel" to "self.set_pixel", which was breaking the function.

`set_multiple_pixels` currently quits with:

```
display.set_pixel(x, y, from_r + (step_r * step), from_g + (step_g * step), from_b + (step_b * step))
NameError: global name 'display' is not defined
```

This modification fixes that.