### PR TITLE
is31fl3731: Fix nextframe index

### DIFF
--- a/library/rgbmatrix5x5/is31fl3731.py
+++ b/library/rgbmatrix5x5/is31fl3731.py
@@ -289,7 +289,7 @@ class Matrix:
         """Show the buffer contents on the display."""
         self.setup()
 
-        next_frame = 0 if self._current_frame == 1 else 0
+        next_frame = 0 if self._current_frame == 1 else 1
 
         output = [0 for x in range(144)]
 


### PR DESCRIPTION
It looks like this what original author wanted,
if not then next_frame should be set to 0 unconditionally

Forwarded: https://github.com/pimoroni/rgbmatrix5x5-python/pulls
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>